### PR TITLE
【設定】Dependabot自動更新設定を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,59 @@
+version: 2
+updates:
+  # npm依存関係の更新
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "nyasuto"
+    assignees:
+      - "nyasuto"
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "javascript"
+    # 自動マージ用のグループ設定
+    groups:
+      # パッチバージョンは一つのPRにまとめる
+      patch-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+      # 開発依存関係のマイナーバージョン更新
+      development-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+    # 除外設定（必要に応じて）
+    ignore:
+      # 例: 特定のパッケージを無視
+      # - dependency-name: "package-name"
+      #   versions: ["1.x", "2.x"]
+
+  # GitHub Actions の更新
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "nyasuto"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
## 概要
依存関係の自動更新のためにDependabotを設定しました。

## 設定内容

### npm依存関係
- **スケジュール**: 毎週月曜日 09:00 (JST)
- **パッチ更新**: 1つのPRにグループ化
- **開発依存関係**: マイナー・パッチを1つのPRにグループ化
- **同時オープンPR数**: 最大10個
- **ラベル**: dependencies, javascript

### GitHub Actions
- **スケジュール**: 毎週月曜日 09:00 (JST)
- **同時オープンPR数**: 最大5個
- **ラベル**: dependencies, github-actions

### 自動設定
- レビュアー・アサイン: @nyasuto
- コミットメッセージ: chore プレフィックス

## メリット
- 依存関係の自動更新でセキュリティ脆弱性を迅速に修正
- グループ化によりPR数を削減
- 定期的なメンテナンス作業の自動化

🤖 Generated with [Claude Code](https://claude.com/claude-code)